### PR TITLE
Add workflow to prevent merging standalone into main

### DIFF
--- a/.github/workflows/prevent_standalone_merge.yml
+++ b/.github/workflows/prevent_standalone_merge.yml
@@ -1,0 +1,16 @@
+name: Prevent merging standalone into main
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  block_merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          if [[ "${{ github.head_ref }}" == "standalone" ]]; then
+            echo "Merging branch 'standalone' into main is not allowed."
+            exit 1
+          fi


### PR DESCRIPTION
To improve usability, we plan to provide a standalone version of BeDivFuzz that implements the core fuzzing algorithm without the experimental infrastructure. For now, the standalone version is planned to be implemented in a separate branch. This workflow aims to ensure that we do not accidentally merge the standalone branch into main.